### PR TITLE
update swcli installation guide

### DIFF
--- a/docs/getting-started/standalone.md
+++ b/docs/getting-started/standalone.md
@@ -2,7 +2,7 @@
 title: Getting started with Starwhale Standalone
 ---
 
-When the [Starwhale Client (swcli)](../swcli) is installed, you are ready to use Starwhale Standalone.
+When the [Starwhale Client (swcli)](../swcli/) is installed, you are ready to use Starwhale Standalone.
 
 We also provide a Jupyter Notebook example, you can try it in [Google Colab](https://colab.research.google.com/github/star-whale/starwhale/blob/main/example/notebooks/quickstart-standalone.ipynb) or in your local [vscode/jupyterlab](https://github.com/star-whale/starwhale/blob/main/example/notebooks/quickstart-standalone.ipynb).
 

--- a/docs/swcli/index.md
+++ b/docs/swcli/index.md
@@ -4,5 +4,5 @@ title: Starwhale Client (swcli) User Guide
 
 The Starwhale Client (`swcli`) is a command-line tool that enables you to interact with Starwhale instances. You can use swcli to complete almost all tasks in Starwhale. `swcli` is written in pure python3 (require Python 3.7 | 3.11) so that it can be easily installed by the `pip` command. Currently, `swcli` only supports Linux and macOS, Windows is coming soon.
 
-- To install/update `swcli`, see the [`swcli` Installation Guide](installation).
-- For a list of commands, see the [`swcli` Reference Guide](../reference/swcli).
+- To install/update `swcli`, see the [`swcli` Installation Guide](./installation/).
+- For a list of commands, see the [`swcli` Reference Guide](../reference/swcli/).

--- a/docs/swcli/installation.md
+++ b/docs/swcli/installation.md
@@ -42,8 +42,7 @@ python3 -m pip install starwhale
 
 swcli --version
 
-sudo rm -rf /usr/local/bin/swcli
-sudo ln -s `which swcli` /usr/local/bin/
+sudo ln -sf "$(which swcli)" /usr/local/bin/
 ```
 
 ### Install with conda
@@ -55,8 +54,7 @@ python3 -m pip install starwhale
 
 swcli --version
 
-sudo rm -rf /usr/local/bin/swcli
-sudo ln -s `which swcli` /usr/local/bin/
+sudo ln -sf "$(which swcli)" /usr/local/bin/
 ```
 
 👏 Now, you can use `swcli` in the global environment.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/getting-started/standalone.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/getting-started/standalone.md
@@ -2,7 +2,7 @@
 title: Starwhale Standalone入门指南
 ---
 
-当[Starwhale Client（swcli）](../swcli)安装完成后，您就可以使用Starwhale Standalone。
+当[Starwhale Client（swcli）](../swcli/)安装完成后，您就可以使用Starwhale Standalone。
 
 我们也提供对应的Jupyter Notebook例子，可以在 [Google Colab](https://colab.research.google.com/github/star-whale/starwhale/blob/main/example/notebooks/quickstart-standalone.ipynb) 或本地的 [vscode/jupyterlab](https://github.com/star-whale/starwhale/blob/main/example/notebooks/quickstart-standalone.ipynb) 中试用。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/swcli/index.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/swcli/index.md
@@ -4,5 +4,5 @@ title: Starwhale Client (swcli) 用户指南
 
 `swcli` 是一个命令行工具，可让您与 Starwhale 实例进行交互。您可以使用 `swcli` 完成 Starwhale 中几乎所有的任务。`swcli` 是用纯 Python3 编写的（需要 Python 3.7 ~ 3.11），因此可以通过 `pip` 命令轻松安装。目前，`swcli` 仅支持 Linux 和 macOS，Windows版本即将推出。
 
-- 要安装/更新 `swcli`，请参阅 [`swcli` 安装指南](installation)。
-- 有关详细的命令列表，请参阅 [`swcli` 参考指南](../reference/swcli)。
+- 要安装/更新 `swcli`，请参阅 [`swcli` 安装指南](./installation/)。
+- 有关详细的命令列表，请参阅 [`swcli` 参考指南](../reference/swcli/)。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/swcli/installation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/swcli/installation.md
@@ -44,8 +44,7 @@ python3 -m pip install starwhale
 
 swcli --version
 
-sudo rm -rf /usr/local/bin/swcli
-sudo ln -s `which swcli` /usr/local/bin/
+sudo ln -sf "$(which swcli)" /usr/local/bin/
 ```
 
 ### 使用conda安装
@@ -57,8 +56,7 @@ python3 -m pip install starwhale
 
 swcli --version
 
-sudo rm -rf /usr/local/bin/swcli
-sudo ln -s `which swcli` /usr/local/bin/
+sudo ln -sf "$(which swcli)" /usr/local/bin/
 ```
 
 👏 现在，您可以在全局环境中使用 `swcli` 了。


### PR DESCRIPTION
- Update swcli installation cmd, use double quotes to make sure it works when the path contains spaces
- Refine links (or it may 404), reproduction:
  - open https://doc.starwhale.ai/getting-started/standalone/ and click the link "When the [Starwhale Client (swcli)](https://doc.starwhale.ai/swcli) is installed'
  - then click the links on the new page



https://github.com/star-whale/docs/assets/3217223/70888f39-320d-44a4-b36d-0ed3a0286823

